### PR TITLE
Setup plugin to account for load balancing changes: Push MFE npm build output to S3 bucket.

### DIFF
--- a/tutormfe_skilredi/patches/local-docker-compose-prod-services
+++ b/tutormfe_skilredi/patches/local-docker-compose-prod-services
@@ -1,7 +1,7 @@
 
 # MFE SkilRedi
 mfe-skilredi:
-    image: {{ MFE_SKILREDI_DOCKER_IMAGE }}
+    image: {{ MFE_DOCKER_IMAGE_SKILREDI }}
     build:
         context: ../plugins/mfe-skilredi/build/mfe/
     restart: unless-stopped

--- a/tutormfe_skilredi/plugin.py
+++ b/tutormfe_skilredi/plugin.py
@@ -13,6 +13,14 @@ config = {
         "HOST": "{{ SKILREDI_MFE_HOST }}",
         "COMMON_VERSION": "{{ OPENEDX_COMMON_VERSION }}",
         "CADDY_DOCKER_IMAGE": "{{ DOCKER_IMAGE_CADDY }}",
+        # S3 MFE Staticfiles
+        # ----------------------
+        # The bucket name to use for S3 static files
+        "STATIC_FILES_BUCKET_NAME": "SET_ME_PLEASE",
+        # AWS S3 settings
+        "AWS_STATIC_FILES_ACCESS_KEY_ID": "SET_ME_PLEASE",
+        "AWS_STATIC_FILES_SECRET_KEY": "SET_ME_PLEASE",
+        "DEPLOY_S3": False,
         "ACCOUNT_MFE_APP_SKILREDI": {
             "name": "account",
             "repository": "https://github.com/edx/frontend-app-account",
@@ -57,7 +65,7 @@ tutor_hooks.Filters.IMAGES_BUILD.add_item(
     (
         "mfe-skilredi",
         ("plugins", "mfe-skilredi", "build", "mfe"),
-        "{{ MFE_SKILREDI_DOCKER_IMAGE }}",
+        "{{ MFE_DOCKER_IMAGE_SKILREDI }}",
         (),
     )
 )
@@ -126,9 +134,9 @@ for path in glob(
 
 # Add configuration entries
 tutor_hooks.Filters.CONFIG_DEFAULTS.add_items(
-    [(f"MFE_{key}", value) for key, value in config.get("defaults", {}).items()]
+    [(f"MFE_{key}_SKILREDI", value) for key, value in config.get("defaults", {}).items()]
 )
 tutor_hooks.Filters.CONFIG_UNIQUE.add_items(
-    [(f"MFE_{key}", value) for key, value in config.get("unique", {}).items()]
+    [(f"MFE_{key}_SKILREDI", value) for key, value in config.get("unique", {}).items()]
 )
 tutor_hooks.Filters.CONFIG_OVERRIDES.add_items(list(config.get("overrides", {}).items()))

--- a/tutormfe_skilredi/templates/mfe-skilredi/build/mfe/Dockerfile
+++ b/tutormfe_skilredi/templates/mfe-skilredi/build/mfe/Dockerfile
@@ -34,7 +34,7 @@ COPY --from={{ app["name"] }}-skilredi-src /openedx/app/src/i18n/messages /opene
 COPY --from=i18n /openedx/i18n/{{ app["name"] }} /openedx/i18n/{{ app["name"] }}
 COPY --from=i18n /openedx/i18n/i18n-merge.js /openedx/i18n/i18n-merge.js
 RUN /openedx/i18n/i18n-merge.js /openedx/app/src/i18n/messages /openedx/i18n/{{ app["name"] }} /openedx/app/src/i18n/messages
-######## {{ app["name"] }} (dev)
+######## {{ app["name"] }} (skilredi-dev)
 FROM base AS {{ app["name"] }}-skilredi-dev
 
 COPY --from={{ app["name"] }}-skilredi-src /openedx/app/package.json /openedx/app/package.json
@@ -50,7 +50,8 @@ RUN npm clean-install --no-audit --no-fund --registry=$NPM_REGISTRY \
 {{ patch("mfe-dockerfile-post-npm-install") }}
 COPY --from={{ app["name"] }}-skilredi-src /openedx/app /openedx/app
 COPY --from={{ app["name"] }}-skilredi-i18n /openedx/app/src/i18n/messages /openedx/app/src/i18n/messages
-ENV PUBLIC_PATH='/{{ app["name"] }}/'
+ENV PUBLIC_PATH='https://{{ MFE_PUBLIC_PATH_SKILREDI }}/{{ app["name"] }}/'
+# ENV PUBLIC_PATH='/{{ app["name"] }}/'
 EXPOSE {{ app['port'] }}
 CMD ["npm", "run", "start"]
 ######## {{ app["name"] }} (production)
@@ -62,8 +63,28 @@ RUN touch /openedx/env/production.override \
   {%- endfor %}
   && echo "done setting production overrides"
 RUN bash -c "set -a && source /openedx/env/production && source /openedx/env/production.override && npm run build"
+
+{% if MFE_DEPLOY_S3_SKILREDI %}
+######## {{ app["name"] }} (skilredi-upload-static-files-to-s3)
+FROM {{ app["name"] }} AS {{ app["name"] }}-skilredi-upload-static-files-to-s3
+
+# Install aws cli
+RUN apt install -y curl unzip && \
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+  unzip awscliv2.zip && \
+  ./aws/install --bin-dir /openedx/bin --install-dir /openedx/aws-cli && rm -r aws awscliv2.zip
+
+# Copy AWS CLI credentials.
+RUN mkdir -p /root/.aws/
+COPY ./aws/config /root/.aws/config
+COPY ./aws/credentials /root/.aws/credentials
+
+RUN /openedx/aws-cli/v2/current/bin/aws --profile s3-uploader s3 sync --delete --follow-symlinks /openedx/app/dist/ s3://{{ MFE_STATIC_FILES_BUCKET_NAME_SKILREDI }}/{{ app["name"] }}/
+{% endif %}
+
 {% endfor %}
 
+{% if not MFE_DEPLOY_S3_SKILREDI %}
 ####### final production image with all static assets
 FROM {{ MFE_CADDY_DOCKER_IMAGE }} as production
 
@@ -76,3 +97,4 @@ COPY --from={{ app["name"] }} /openedx/app/dist /openedx/dist/{{ app["name"] }}
 
 # Copy caddy config file
 COPY ./Caddyfile /etc/caddy/Caddyfile
+{% endif %}

--- a/tutormfe_skilredi/templates/mfe-skilredi/build/mfe/aws/config
+++ b/tutormfe_skilredi/templates/mfe-skilredi/build/mfe/aws/config
@@ -1,0 +1,4 @@
+# Profile for S3 upload
+[profile s3-uploader]
+region=us-east-1
+output=json

--- a/tutormfe_skilredi/templates/mfe-skilredi/build/mfe/aws/credentials
+++ b/tutormfe_skilredi/templates/mfe-skilredi/build/mfe/aws/credentials
@@ -1,0 +1,4 @@
+# Profile for S3 uploader
+[s3-uploader]
+aws_access_key_id = {{ MFE_AWS_STATIC_FILES_ACCESS_KEY_ID_SKILREDI }}
+aws_secret_access_key = {{ MFE_AWS_STATIC_FILES_SECRET_KEY_SKILREDI }}


### PR DESCRIPTION
When setting the `MFE_DEPLOY_S3_SKILREDI` tutor environment variable to true, this will send all publish `npm build` files for this MFE to the S3 bucket defined at `MFE_STATIC_FILES_BUCKET_NAME_SKILREDI`.
